### PR TITLE
Added MathJax support

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,2 +1,8 @@
 <link rel="shortcut icon" href="/assets/images/logo/stellar-vector-main-round-transparant.ico" type="image/x-icon">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@48,400,0,0" />
+{% assign math = page.math | default: layout.math | default: site.math %}
+
+{% case math %}
+  {% when "mathjax" %}
+    {% include mathjax.html %}
+{% endcase %}

--- a/_includes/mathjax.html
+++ b/_includes/mathjax.html
@@ -1,6 +1,6 @@
 <!-- Automatically display code inside script tags with type=math/tex using MathJax -->
 <script type="text/javascript" defer
-  src="/just-the-docs-tests/assets/js/mathjax-script-type.js">
+  src="/assets/js/mathjax-script-type.js">
 </script>
 
 <!-- Copied from https://docs.mathjax.org/en/latest/web/components/combined.html -->

--- a/_includes/mathjax.html
+++ b/_includes/mathjax.html
@@ -1,0 +1,9 @@
+<!-- Automatically display code inside script tags with type=math/tex using MathJax -->
+<script type="text/javascript" defer
+  src="/just-the-docs-tests/assets/js/mathjax-script-type.js">
+</script>
+
+<!-- Copied from https://docs.mathjax.org/en/latest/web/components/combined.html -->
+<script type="text/javascript" id="MathJax-script" defer
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js">
+</script>

--- a/_layouts/mathjax.html
+++ b/_layouts/mathjax.html
@@ -1,0 +1,12 @@
+---
+layout: default
+math: mathjax
+---
+<div style="display: none">
+  \(
+  <!-- optional definitions using \newcommand, etc. 
+       see https://docs.mathjax.org/en/latest/input/tex/macros.html -->
+  \)
+</div>
+
+{{ content }}

--- a/_layouts/mathjax.html
+++ b/_layouts/mathjax.html
@@ -6,6 +6,9 @@ math: mathjax
   \(
   <!-- optional definitions using \newcommand, etc. 
        see https://docs.mathjax.org/en/latest/input/tex/macros.html -->
+    \newcommand{\R}{\mathbb{R}}
+    \newcommand{\Q}{\mathbb{Q}}
+    \newcommand{\Z}{\mathbb{Z}}
   \)
 </div>
 

--- a/_templates/writeup.template
+++ b/_templates/writeup.template
@@ -9,6 +9,7 @@ title: "<challenge>"
 subtitle: "<subtitle>"
 write_date: <date>
 last_edit_date:
+# layout: mathjax # Uncomment this line to enable MathJax
 ---
 
 Write your writeup here...

--- a/_writeups/2023/downunderctf/apbq-rsa-1.md
+++ b/_writeups/2023/downunderctf/apbq-rsa-1.md
@@ -9,6 +9,7 @@ title: "apbq-rsa-1"
 subtitle: ""
 write_date: 2023-09-07
 last_edit_date:
+layout: mathjax # Uncomment this line to enable MathJax
 ---
 
 ## Challenge description
@@ -50,8 +51,11 @@ We must find a way to use the hints instead.
 
 The first observation is the following.
 Let us call our hints `h1 = a1*p + b1*q` and `h2 = a2*p + b2*q`.
-Then if only we knew `a1` and `a2` we could compute `H = a1*h2 - a2*h1`, to obtain `(a1*b2 - a2*b1)*q`.
-Now this number shares a factor (`q`) with our public modulus `n`; we can efficently compute `gcd(n, H) = q`, and then recover `p = n // q`.
+Then if only we knew `a1` and `a2` we could compute 
+
+$$H = a_1 h_2 - a_2 h_1 = (a_1b_2 - a_2b_1)q$$
+
+Now this number shares a factor `q` with our public modulus `n`; we can efficently compute `gcd(n, H) = q`, and then recover `p = n // q`.
 Of course the same reasoning applies to `b1*h2 - b2*h1` which gives us `p`.
 
 This would allow us to recover the flag.
@@ -101,7 +105,15 @@ assert n % q == 0
 p = n // q
 ```
 
-Once we have `p` and `q` we can compute `phi = (p-1)*(q-1)`, and then `d = pow(e, -1, phi)`, the private exponent we need to invert the ciphertext.
+Once we have `p` and `q` we can compute 
+
+$$\varphi = (p-1)(q-1),$$
+
+and then 
+
+$$d = e^{-1} \bmod \varphi,$$ 
+
+the private exponent we need to invert the ciphertext.
 In this way we finally recover the flag:
 
 ```python

--- a/assets/js/mathjax-script-type.js
+++ b/assets/js/mathjax-script-type.js
@@ -1,0 +1,18 @@
+// Copied from https://docs.mathjax.org/en/latest/upgrading/v2.html#changes-in-the-mathjax-api
+MathJax = {
+  options: {
+    renderActions: {
+      findScript: [10, function (doc) {
+        for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
+          const display = !!node.type.match(/; *mode=display/);
+          const math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
+          const text = document.createTextNode('');
+          node.parentNode.replaceChild(text, node);
+          math.start = {node: text, delim: '', n: 0};
+          math.end = {node: text, delim: '', n: 0};
+          doc.math.push(math);
+        }
+      }, '']
+    }
+  }
+};


### PR DESCRIPTION
Closes #4 
Added mathjax support as described [here](https://just-the-docs.github.io/just-the-docs-tests/components/math/mathjax/config/)
Tested it fixing the math in the rsa writeup
Fixed the import in `_includes/mathjax.html` (was pointing to absolute path in their repo)
Added custom latex commands in `_layouts/mathjax.html` as an example 
Added optional mathjax line `# layout: mathjax # Uncomment this line to enable MathJax` to the writeup template (tested locally) - it can also be enabled globally setting `math: mathjax` in `_config.yml` but usually that slows down loading
